### PR TITLE
Update README.md to show percentage of memory saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 583,398 bytes
 - Optimized Size: 195,430 bytes
 - DSSIM similarity score: 0.001504
+- Memory saved: 66.50%
 
 ##### Original
 
@@ -73,6 +74,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 138,272
 - Optimized Size: 64,982
 - DSSIM similarity score: 0.000913
+- Memory saved: 53.00%
 
 ##### Original
 
@@ -88,6 +90,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 196,794 bytes
 - Optimized Size: 77,968 bytes
 - DSSIM similarity score: 0.002988
+- Memory saved: 63.38%
 
 ##### Original
 
@@ -106,6 +109,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 197,193 bytes
 - Optimized Size: 67,773 bytes
 - DSSIM similarity score: 0.000163
+- Memory saved: 65.63%
 
 ##### Original
 
@@ -120,6 +124,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 249,251 bytes
 - Optiimized Size: 67,326 bytes
 - DSSIM similarity score: 0.002503
+- Memory saved: 72.99%
 
 ##### Original
 
@@ -135,6 +140,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 440,126 bytes
 - Optimized Size: 196,979 bytes
 - DSSIM similarity score: 0.000481
+- Memory saved: 55.24%
 
 ##### Original
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 583,398 bytes
 - Optimized Size: 195,430 bytes
 - DSSIM similarity score: 0.001504
-- Memory saved: 66.50%
+- Percent original size: 66.50%
 
 ##### Original
 
@@ -74,7 +74,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 138,272
 - Optimized Size: 64,982
 - DSSIM similarity score: 0.000913
-- Memory saved: 53.00%
+- Percent original size: 53.00%
 
 ##### Original
 
@@ -90,7 +90,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 196,794 bytes
 - Optimized Size: 77,968 bytes
 - DSSIM similarity score: 0.002988
-- Memory saved: 63.38%
+- Percent original size: 63.38%
 
 ##### Original
 
@@ -109,7 +109,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 197,193 bytes
 - Optimized Size: 67,773 bytes
 - DSSIM similarity score: 0.000163
-- Memory saved: 65.63%
+- Percent original size: 65.63%
 
 ##### Original
 
@@ -124,7 +124,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 249,251 bytes
 - Optiimized Size: 67,326 bytes
 - DSSIM similarity score: 0.002503
-- Memory saved: 72.99%
+- Percent original size: 72.99%
 
 ##### Original
 
@@ -140,7 +140,7 @@ The following examples demonstrate the benefits and disadvantages of the current
 - Original Size: 440,126 bytes
 - Optimized Size: 196,979 bytes
 - DSSIM similarity score: 0.000481
-- Memory saved: 55.24%
+- Percent original size: 55.24%
 
 ##### Original
 


### PR DESCRIPTION
For each of the demo pictures in README.md, it might be useful to show the percentage of memory saved by using Crunch's optimizations alongside the Original/Optimized Size and DSSIM similarity score.

Memory saved = (Original_Size - Optimized_Size) / Original_Size

See [Issue 35](https://github.com/chrissimpkins/Crunch/issues/35)