### PR TITLE
Support simple redefinition of pnquant/zopflipng paths in the command line executable

### DIFF
--- a/docs/EXECUTABLE.md
+++ b/docs/EXECUTABLE.md
@@ -40,7 +40,7 @@ During the `make build-dependencies` step, your terminal window will display len
 
 sudo permissions are required to move the executable to your `/usr/bin/local` directory. Please enter your password when it is requested.
 
-### 2. Install manually from scratch
+### 2. Install manually
 
 ```
 $ src/install-dependencies.sh
@@ -58,17 +58,6 @@ $ crunch --help
 ```
 
 This command should display the in-application help message for the `crunch` executable.  If you see this text, you are all set to use `crunch`.
-
-### 3. Install manually with Homebrew
-
-Crunch itself isn't currently available in Homebrew, but if you wish you can install the `pngquant` and `zopflipng` dependencies through Homebrew:
-
-```
-$ brew install pngquant
-$ brew install zopfli
-```
-
-Once installed, you can then copy the `crunch.py` script to somewhere in your path and it will use the Homebrew installed version of the dependencies.
 
 ## Usage
 

--- a/src/crunch.py
+++ b/src/crunch.py
@@ -22,8 +22,18 @@ from multiprocessing import Lock, Pool, cpu_count
 # Locks
 lock = Lock()
 
-# Processor Constants
-PROCESSES = 0  # detected automatically in source if this is defined as zero
+# Processor Constant
+#  - Modify this to an integer value if you want to fix the number of
+#    processes spawned during execution.  The process number is 
+#    automatically defined during source execution when this is defined
+#    as a value of 0
+PROCESSES = 0 
+
+# Dependency Path Constants for Command Line Executable
+#  - Redefine these path strings to use system-installed versions of
+#    pngquant and zopflipng (e.g. to "/usr/local/bin/[executable]")
+PNGQUANT_CLI_PATH = os.path.join(os.path.expanduser("~"), "pngquant", "pngquant")
+ZOPFLIPNG_CLI_PATH = os.path.join(os.path.expanduser("~"), "zopfli", "zopflipng")
 
 # Application Constants
 VERSION = "2.0.2"
@@ -245,11 +255,8 @@ def get_pngquant_path():
         return "./pngquant"
     elif sys.argv[1] == "--service":
         return "/Applications/Crunch.app/Contents/Resources/pngquant"
-    # if installed by homebrew
-    elif os.path.exists('/usr/local/bin/pngquant'):
-        return '/usr/local/bin/pngquant'
     else:
-        return os.path.join(os.path.expanduser("~"), "pngquant", "pngquant")
+        return PNGQUANT_CLI_PATH
 
 
 def get_zopflipng_path():
@@ -257,11 +264,8 @@ def get_zopflipng_path():
         return "./zopflipng"
     elif sys.argv[1] == "--service":
         return "/Applications/Crunch.app/Contents/Resources/zopflipng"
-    # if installed by homebrew
-    elif os.path.exists('/usr/local/bin/zopflipng'):
-        return '/usr/local/bin/zopflipng'
     else:
-        return os.path.join(os.path.expanduser("~"), "zopfli", "zopflipng")
+        return ZOPFLIPNG_CLI_PATH
 
 
 def shellquote(filepath):

--- a/src/crunch.py
+++ b/src/crunch.py
@@ -24,10 +24,10 @@ lock = Lock()
 
 # Processor Constant
 #  - Modify this to an integer value if you want to fix the number of
-#    processes spawned during execution.  The process number is 
+#    processes spawned during execution.  The process number is
 #    automatically defined during source execution when this is defined
 #    as a value of 0
-PROCESSES = 0 
+PROCESSES = 0
 
 # Dependency Path Constants for Command Line Executable
 #  - Redefine these path strings to use system-installed versions of


### PR DESCRIPTION
Associated issue report: #40 