### PR TITLE
Add option to replace the original file with -f flag

### DIFF
--- a/src/crunch.py
+++ b/src/crunch.py
@@ -66,6 +66,7 @@ Options:
     --help, -h      application help
     --usage         application usage
     --version, -v   application version
+    --force, -f     override (force) the original file
 """
 
 USAGE = "$ crunch [image path 1]...[image path n]"

--- a/src/crunch.py
+++ b/src/crunch.py
@@ -69,9 +69,11 @@ Options:
 """
 
 USAGE = "$ crunch [image path 1]...[image path n]"
+FORCE = False
 
 
 def main(argv):
+    global FORCE
 
     # Create the Crunch dot directory in $HOME if it does not exist
     # Only used for macOS GUI and macOS right-click menu service execution
@@ -133,6 +135,10 @@ def main(argv):
     # //////////////////////////////////
     # COMMAND LINE ERROR HANDLING
     # //////////////////////////////////
+
+    if argv[0] in ("-f", "--force"):
+        png_path_list.remove(argv[0])
+        FORCE = True
 
     NOTPNG_ERROR_FOUND = False
     for png_path in png_path_list:
@@ -253,6 +259,8 @@ def main(argv):
 
 
 def optimize_png(png_path):
+    global FORCE
+
     img = ImageFile(png_path)
 
     # define pngquant and zopflipng paths
@@ -408,6 +416,19 @@ def optimize_png(png_path):
             + str(img.post_size)
             + " bytes)"
         )
+
+    if FORCE == True:
+        try:
+            os.remove(img.pre_filepath)
+            shutil.move(img.post_filepath, img.pre_filepath)
+            stdstream_lock.acquire()
+            print("Moved {} to {}".format(img.post_filepath, img.pre_filepath))
+            stdstream_lock.release()
+        except Exception as e:
+            stdstream_lock.acquire()
+            sys.stderr.write("Error: Unable to overwrite pre image file {}.  Error message: {}".format(
+                img.pre_filepath, e))
+            stdstream_lock.release()
 
 
 # -----------


### PR DESCRIPTION
Hi,

with your code adjustments and a little bit of research, I was able to implement the `-f`, `--force` flag. By providing this flag as a first argument you can now replace the original file.

Feel free to refactor my code if it's crap ;). Like I said before I'm not a Python dev.

Examples:

Single file
```
crunch -f file.png
```

Directory recursive
```
find. -name "*.png" | xargs crunch -f
```

Tested on macOS Catalina, Version: 10.15.1 (19B88)