### PR TITLE
Ignore Python std lib warnings

### DIFF
--- a/src/crunch.py
+++ b/src/crunch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3 -Wignore
+#!/usr/bin/env -S python3 -Wignore
 
 # ==================================================================
 #  crunch

--- a/src/crunch.py
+++ b/src/crunch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3 -Wignore
 
 # ==================================================================
 #  crunch


### PR DESCRIPTION
Closes #100

This is heavy handed but I can't get selective ignores to function with Python std lib `warnings` methods.